### PR TITLE
Add RC1 Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/ncw/swift v1.0.47
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
-	github.com/oras-project/artifacts-spec v1.0.0-draft.1
+	github.com/oras-project/artifacts-spec v1.0.0-rc.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.0.0
 	github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVo
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/oras-project/artifacts-spec v1.0.0-draft.1 h1:AyD++MU8sif5eyyvPbT5qskkJA9VZynYVoroVFTXPLM=
 github.com/oras-project/artifacts-spec v1.0.0-draft.1/go.mod h1:Xch2aLzSwtkhbFFN6LUzTfLtukYvMMdXJ4oZ8O7BOdc=
+github.com/oras-project/artifacts-spec v1.0.0-rc.1 h1:bCHf9mPbrgiNwQFyVzBX79BYZVAl0OUrmvICZOCOwts=
+github.com/oras-project/artifacts-spec v1.0.0-rc.1/go.mod h1:Xch2aLzSwtkhbFFN6LUzTfLtukYvMMdXJ4oZ8O7BOdc=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/registry/api/v2/errors.go
+++ b/registry/api/v2/errors.go
@@ -154,4 +154,14 @@ var (
 		to return) is not an integer, or "n" is negative.`,
 		HTTPStatusCode: http.StatusBadRequest,
 	})
+
+	// ErrorCodeReferrerNotFound is returned if a client provides an invalid referrer digest
+	// in the `nextToken` field
+	ErrorCodeReferrerNotFound = errcode.Register("errcode", errcode.ErrorDescriptor{
+		Value:   "REFERRER_NOT_FOUND",
+		Message: "referrer with digest not found",
+		Description: `Returned if a client provides an invalid referrer digest
+		in the "nextToken" for pagination`,
+		HTTPStatusCode: http.StatusNotFound,
+	})
 )

--- a/registry/api/v2/errors.go
+++ b/registry/api/v2/errors.go
@@ -155,13 +155,13 @@ var (
 		HTTPStatusCode: http.StatusBadRequest,
 	})
 
-	// ErrorCodeReferrerNotFound is returned if a client provides an invalid referrer digest
-	// in the `nextToken` field
-	ErrorCodeReferrerNotFound = errcode.Register("errcode", errcode.ErrorDescriptor{
-		Value:   "REFERRER_NOT_FOUND",
-		Message: "referrer with digest not found",
-		Description: `Returned if a client provides an invalid referrer digest
-		in the "nextToken" for pagination`,
-		HTTPStatusCode: http.StatusNotFound,
+	// ErrorCodeMalformedNextToken is returned when uploading a blob if the
+	// provided digest does not match the blob contents.
+	ErrorCodeMalformedNextToken = errcode.Register(errGroup, errcode.ErrorDescriptor{
+		Value:   "MALFORMED_NEXTTOKEN",
+		Message: "provided nextToken is invalid",
+		Description: `Returned if a client provides a non-empty nextToken value that
+		cannot be properly parsed`,
+		HTTPStatusCode: http.StatusBadRequest,
 	})
 )

--- a/registry/api/v2/extensions.go
+++ b/registry/api/v2/extensions.go
@@ -18,10 +18,10 @@ func ExtendRoute(ns, ext, component string, template RouteDescriptor, nameRequir
 	path := routeDescriptorsMap[RouteNameBase].Path
 	if nameRequired {
 		name = RouteNameExtensionsRepository
-		path += "{name:" + reference.NameRegexp.String() + "}"
+		path += "{name:" + reference.NameRegexp.String() + "}/"
 	}
 	name = fmt.Sprintf("%s-%s-%s-%s", name, ns, ext, component)
-	path = fmt.Sprintf("%s/_%s/%s/%s", path, ns, ext, component)
+	path = fmt.Sprintf("%s_%s/%s/%s", path, ns, ext, component)
 
 	desc := template
 	desc.Name = name

--- a/registry/extension/extension.go
+++ b/registry/extension/extension.go
@@ -80,19 +80,16 @@ func EnumerateRegistered(ctx Context) (enumeratedExtensions []EnumerateExtension
 			Endpoints:   []string{},
 		}
 
+		scopedRoutes := namespace.GetRepositoryRoutes()
+
 		// if the repository is not set in the context, scope is registry wide
 		if ctx.Repository == nil {
-			registryScoped := namespace.GetRegistryRoutes()
-			for _, regScoped := range registryScoped {
-				path := fmt.Sprintf("_%s/%s/%s", regScoped.Namespace, regScoped.Extension, regScoped.Component)
-				enumerateExtension.Endpoints = append(enumerateExtension.Endpoints, path)
-			}
-		} else {
-			repositoryScoped := namespace.GetRepositoryRoutes()
-			for _, repScoped := range repositoryScoped {
-				path := fmt.Sprintf("_%s/%s/%s", repScoped.Namespace, repScoped.Extension, repScoped.Component)
-				enumerateExtension.Endpoints = append(enumerateExtension.Endpoints, path)
-			}
+			scopedRoutes = namespace.GetRegistryRoutes()
+		}
+
+		for _, route := range scopedRoutes {
+			path := fmt.Sprintf("_%s/%s/%s", route.Namespace, route.Extension, route.Component)
+			enumerateExtension.Endpoints = append(enumerateExtension.Endpoints, path)
 		}
 
 		// add extension to list if endpoints exist

--- a/registry/extension/extension.go
+++ b/registry/extension/extension.go
@@ -1,7 +1,6 @@
 package extension
 
 import (
-	"context"
 	c "context"
 	"fmt"
 	"net/http"
@@ -72,27 +71,34 @@ type EnumerateExtension struct {
 var extensions map[string]InitExtensionNamespace
 var extensionsNamespaces map[string]Namespace
 
-func EnumerateRegistered(ctx context.Context) (enumeratedExtensions []EnumerateExtension) {
+func EnumerateRegistered(ctx Context) (enumeratedExtensions []EnumerateExtension) {
 	for _, namespace := range extensionsNamespaces {
 		enumerateExtension := EnumerateExtension{
 			Name:        namespace.GetNamespaceName(),
 			Url:         namespace.GetNamespaceUrl(),
 			Description: namespace.GetNamespaceDescription(),
+			Endpoints:   []string{},
 		}
 
-		registryScoped := namespace.GetRegistryRoutes()
-		for _, regScoped := range registryScoped {
-			path := fmt.Sprintf("_%s/%s/%s", regScoped.Namespace, regScoped.Extension, regScoped.Component)
-			enumerateExtension.Endpoints = append(enumerateExtension.Endpoints, path)
+		// if the repository is not set in the context, scope is registry wide
+		if ctx.Repository == nil {
+			registryScoped := namespace.GetRegistryRoutes()
+			for _, regScoped := range registryScoped {
+				path := fmt.Sprintf("_%s/%s/%s", regScoped.Namespace, regScoped.Extension, regScoped.Component)
+				enumerateExtension.Endpoints = append(enumerateExtension.Endpoints, path)
+			}
+		} else {
+			repositoryScoped := namespace.GetRepositoryRoutes()
+			for _, repScoped := range repositoryScoped {
+				path := fmt.Sprintf("_%s/%s/%s", repScoped.Namespace, repScoped.Extension, repScoped.Component)
+				enumerateExtension.Endpoints = append(enumerateExtension.Endpoints, path)
+			}
 		}
 
-		repositoryScoped := namespace.GetRepositoryRoutes()
-		for _, repScoped := range repositoryScoped {
-			path := fmt.Sprintf("_%s/%s/%s", repScoped.Namespace, repScoped.Extension, repScoped.Component)
-			enumerateExtension.Endpoints = append(enumerateExtension.Endpoints, path)
+		// add extension to list if endpoints exist
+		if len(enumerateExtension.Endpoints) > 0 {
+			enumeratedExtensions = append(enumeratedExtensions, enumerateExtension)
 		}
-
-		enumeratedExtensions = append(enumeratedExtensions, enumerateExtension)
 	}
 
 	return enumeratedExtensions

--- a/registry/extension/oci/discover.go
+++ b/registry/extension/oci/discover.go
@@ -25,7 +25,7 @@ func (th *extensionHandler) getExtensions(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json")
 
 	// get list of extension information seperated at the namespace level
-	enumeratedExtensions := extension.EnumerateRegistered(r.Context())
+	enumeratedExtensions := extension.EnumerateRegistered(*th.Context)
 
 	// remove the oci extension so it's not returned by discover
 	for i, e := range enumeratedExtensions {

--- a/registry/extension/oci/discover.go
+++ b/registry/extension/oci/discover.go
@@ -19,13 +19,13 @@ type extensionHandler struct {
 	storageDriver driver.StorageDriver
 }
 
-func (th *extensionHandler) getExtensions(w http.ResponseWriter, r *http.Request) {
+func (eh *extensionHandler) getExtensions(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	w.Header().Set("Content-Type", "application/json")
 
 	// get list of extension information seperated at the namespace level
-	enumeratedExtensions := extension.EnumerateRegistered(*th.Context)
+	enumeratedExtensions := extension.EnumerateRegistered(*eh.Context)
 
 	// remove the oci extension so it's not returned by discover
 	for i, e := range enumeratedExtensions {
@@ -38,7 +38,7 @@ func (th *extensionHandler) getExtensions(w http.ResponseWriter, r *http.Request
 	if err := enc.Encode(discoverGetAPIResponse{
 		Extensions: enumeratedExtensions,
 	}); err != nil {
-		th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
+		eh.Errors = append(eh.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 		return
 	}
 }

--- a/registry/extension/oci/discover.go
+++ b/registry/extension/oci/discover.go
@@ -10,7 +10,6 @@ import (
 )
 
 type discoverGetAPIResponse struct {
-	Name       string                         `json:"name"`
 	Extensions []extension.EnumerateExtension `json:"extensions"`
 }
 
@@ -37,7 +36,6 @@ func (th *extensionHandler) getExtensions(w http.ResponseWriter, r *http.Request
 
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(discoverGetAPIResponse{
-		Name:       th.Repository.Named().Name(),
 		Extensions: enumeratedExtensions,
 	}); err != nil {
 		th.Errors = append(th.Errors, errcode.ErrorCodeUnknown.WithDetail(err))

--- a/registry/extension/oci/oci.go
+++ b/registry/extension/oci/oci.go
@@ -95,9 +95,28 @@ func (d *ociNamespace) GetRepositoryRoutes() []extension.Route {
 }
 
 // GetRegistryRoutes returns a list of extension routes scoped at a registry level
-// There are no registry scoped routes exposed by this namespace
 func (d *ociNamespace) GetRegistryRoutes() []extension.Route {
-	return nil
+	var routes []extension.Route
+
+	if d.discoverEnabled {
+		routes = append(routes, extension.Route{
+			Namespace: namespaceName,
+			Extension: extensionName,
+			Component: discoverComponentName,
+			Descriptor: v2.RouteDescriptor{
+				Entity: "Extension",
+				Methods: []v2.MethodDescriptor{
+					{
+						Method:      "GET",
+						Description: "Get all extensions enabled for a registry.",
+					},
+				},
+			},
+			Dispatcher: d.discoverDispatcher,
+		})
+	}
+
+	return routes
 }
 
 // GetNamespaceName returns the name associated with the namespace

--- a/registry/extension/oci/oci.go
+++ b/registry/extension/oci/oci.go
@@ -70,10 +70,10 @@ func (o *ociNamespace) GetManifestHandlers(repo distribution.Repository, blobSto
 }
 
 // GetRepositoryRoutes returns a list of extension routes scoped at a repository level
-func (d *ociNamespace) GetRepositoryRoutes() []extension.Route {
+func (o *ociNamespace) GetRepositoryRoutes() []extension.Route {
 	var routes []extension.Route
 
-	if d.discoverEnabled {
+	if o.discoverEnabled {
 		routes = append(routes, extension.Route{
 			Namespace: namespaceName,
 			Extension: extensionName,
@@ -87,7 +87,7 @@ func (d *ociNamespace) GetRepositoryRoutes() []extension.Route {
 					},
 				},
 			},
-			Dispatcher: d.discoverDispatcher,
+			Dispatcher: o.discoverDispatcher,
 		})
 	}
 
@@ -95,10 +95,10 @@ func (d *ociNamespace) GetRepositoryRoutes() []extension.Route {
 }
 
 // GetRegistryRoutes returns a list of extension routes scoped at a registry level
-func (d *ociNamespace) GetRegistryRoutes() []extension.Route {
+func (o *ociNamespace) GetRegistryRoutes() []extension.Route {
 	var routes []extension.Route
 
-	if d.discoverEnabled {
+	if o.discoverEnabled {
 		routes = append(routes, extension.Route{
 			Namespace: namespaceName,
 			Extension: extensionName,
@@ -112,7 +112,7 @@ func (d *ociNamespace) GetRegistryRoutes() []extension.Route {
 					},
 				},
 			},
-			Dispatcher: d.discoverDispatcher,
+			Dispatcher: o.discoverDispatcher,
 		})
 	}
 
@@ -120,24 +120,24 @@ func (d *ociNamespace) GetRegistryRoutes() []extension.Route {
 }
 
 // GetNamespaceName returns the name associated with the namespace
-func (d *ociNamespace) GetNamespaceName() string {
+func (o *ociNamespace) GetNamespaceName() string {
 	return namespaceName
 }
 
 // GetNamespaceUrl returns the url link to the documentation where the namespace's extension and endpoints are defined
-func (d *ociNamespace) GetNamespaceUrl() string {
+func (o *ociNamespace) GetNamespaceUrl() string {
 	return namespaceUrl
 }
 
 // GetNamespaceDescription returns the description associated with the namespace
-func (d *ociNamespace) GetNamespaceDescription() string {
+func (o *ociNamespace) GetNamespaceDescription() string {
 	return namespaceDescription
 }
 
-func (d *ociNamespace) discoverDispatcher(ctx *extension.Context, r *http.Request) http.Handler {
+func (o *ociNamespace) discoverDispatcher(ctx *extension.Context, r *http.Request) http.Handler {
 	extensionHandler := &extensionHandler{
 		Context:       ctx,
-		storageDriver: d.storageDriver,
+		storageDriver: o.storageDriver,
 	}
 
 	return handlers.MethodHandler{

--- a/registry/extension/oras/artifactmanifest.go
+++ b/registry/extension/oras/artifactmanifest.go
@@ -42,6 +42,11 @@ func (a Manifest) Annotations() map[string]string {
 	return a.inner.Annotations
 }
 
+// MediaType returns the media type of this ORAS artifact.
+func (a Manifest) MediaType() string {
+	return a.inner.MediaType
+}
+
 // References returns the distribution descriptors for the referenced blobs.
 func (a Manifest) References() []distribution.Descriptor {
 	blobs := make([]distribution.Descriptor, len(a.inner.Blobs))
@@ -84,7 +89,10 @@ func (d *DeserializedManifest) UnmarshalJSON(b []byte) error {
 	if man.ArtifactType == "" {
 		return errors.New("artifactType cannot be empty")
 	}
-	// TODO: add media type enforcement?
+	if man.MediaType == "" {
+		return errors.New("mediaType cannot be empty")
+	}
+
 	d.inner = man
 
 	return nil

--- a/registry/extension/oras/artifactmanifest.go
+++ b/registry/extension/oras/artifactmanifest.go
@@ -37,6 +37,11 @@ func (a Manifest) ArtifactType() string {
 	return a.inner.ArtifactType
 }
 
+// Annotations returns the annotations of this ORAS artifact.
+func (a Manifest) Annotations() map[string]string {
+	return a.inner.Annotations
+}
+
 // References returns the distribution descriptors for the referenced blobs.
 func (a Manifest) References() []distribution.Descriptor {
 	blobs := make([]distribution.Descriptor, len(a.inner.Blobs))
@@ -79,6 +84,7 @@ func (d *DeserializedManifest) UnmarshalJSON(b []byte) error {
 	if man.ArtifactType == "" {
 		return errors.New("artifactType cannot be empty")
 	}
+	// TODO: add media type enforcement?
 	d.inner = man
 
 	return nil

--- a/registry/extension/oras/artifactmanifest.go
+++ b/registry/extension/oras/artifactmanifest.go
@@ -89,8 +89,8 @@ func (d *DeserializedManifest) UnmarshalJSON(b []byte) error {
 	if man.ArtifactType == "" {
 		return errors.New("artifactType cannot be empty")
 	}
-	if man.MediaType == "" {
-		return errors.New("mediaType cannot be empty")
+	if man.MediaType != v1.MediaTypeArtifactManifest {
+		return errors.New("mediaType is invalid")
 	}
 
 	d.inner = man

--- a/registry/extension/oras/artifactmanifesthandler.go
+++ b/registry/extension/oras/artifactmanifesthandler.go
@@ -89,7 +89,7 @@ func (amh *artifactManifestHandler) verifyManifest(ctx context.Context, dm Deser
 			errs = append(errs, distribution.ErrManifestVerification{errors.New("failed to parse created time: " + err.Error())})
 		}
 	}
-	// TODO: check that created annotation has correct format
+
 	if !skipDependencyVerification {
 		bs := amh.repository.Blobs(ctx)
 

--- a/registry/extension/oras/artifactmanifesthandler.go
+++ b/registry/extension/oras/artifactmanifesthandler.go
@@ -14,6 +14,12 @@ import (
 	v1 "github.com/oras-project/artifacts-spec/specs-go/v1"
 )
 
+var (
+	errInvalidArtifactType      = errors.New("artifactType invalid")
+	errInvalidMediaType         = errors.New("mediaType invalid")
+	errInvalidCreatedAnnotation = errors.New("failed to parse created time")
+)
+
 // artifactManifestHandler is a ManifestHandler that covers ORAS Artifacts.
 type artifactManifestHandler struct {
 	repository    distribution.Repository
@@ -77,17 +83,17 @@ func (amh *artifactManifestHandler) verifyManifest(ctx context.Context, dm Deser
 	var errs distribution.ErrManifestVerification
 
 	if dm.ArtifactType() == "" {
-		errs = append(errs, distribution.ErrManifestVerification{errors.New("artifactType invalid")})
+		errs = append(errs, errInvalidArtifactType)
 	}
 
 	if dm.MediaType() != v1.MediaTypeArtifactManifest {
-		errs = append(errs, distribution.ErrManifestVerification{errors.New("mediaType invalid")})
+		errs = append(errs, errInvalidMediaType)
 	}
 
 	if createdAt, ok := dm.Annotations()[createAnnotationName]; ok {
 		_, err := time.Parse(time.RFC3339, createdAt)
 		if err != nil {
-			errs = append(errs, distribution.ErrManifestVerification{errors.New("failed to parse created time: " + err.Error())})
+			errs = append(errs, errInvalidCreatedAnnotation)
 		}
 	}
 

--- a/registry/extension/oras/artifactmanifesthandler.go
+++ b/registry/extension/oras/artifactmanifesthandler.go
@@ -11,6 +11,7 @@ import (
 	dcontext "github.com/distribution/distribution/v3/context"
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/opencontainers/go-digest"
+	v1 "github.com/oras-project/artifacts-spec/specs-go/v1"
 )
 
 // artifactManifestHandler is a ManifestHandler that covers ORAS Artifacts.
@@ -79,7 +80,7 @@ func (amh *artifactManifestHandler) verifyManifest(ctx context.Context, dm Deser
 		errs = append(errs, distribution.ErrManifestVerification{errors.New("artifactType invalid")})
 	}
 
-	if dm.MediaType() == "" {
+	if dm.MediaType() != v1.MediaTypeArtifactManifest {
 		errs = append(errs, distribution.ErrManifestVerification{errors.New("mediaType invalid")})
 	}
 

--- a/registry/extension/oras/artifactmanifesthandler.go
+++ b/registry/extension/oras/artifactmanifesthandler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"path"
+	"time"
 
 	"github.com/distribution/distribution/v3"
 	dcontext "github.com/distribution/distribution/v3/context"
@@ -77,7 +78,18 @@ func (amh *artifactManifestHandler) verifyManifest(ctx context.Context, dm Deser
 	if dm.ArtifactType() == "" {
 		errs = append(errs, distribution.ErrManifestVerification{errors.New("artifactType invalid")})
 	}
-	// TODO: check that media type exists
+
+	if dm.MediaType() == "" {
+		errs = append(errs, distribution.ErrManifestVerification{errors.New("mediaType invalid")})
+	}
+
+	if createdAt, ok := dm.Annotations()[createAnnotationName]; ok {
+		_, err := time.Parse(time.RFC3339, createdAt)
+		if err != nil {
+			errs = append(errs, distribution.ErrManifestVerification{errors.New("failed to parse created time: " + err.Error())})
+		}
+	}
+	// TODO: check that created annotation has correct format
 	if !skipDependencyVerification {
 		bs := amh.repository.Blobs(ctx)
 

--- a/registry/extension/oras/artifactmanifesthandler.go
+++ b/registry/extension/oras/artifactmanifesthandler.go
@@ -77,7 +77,7 @@ func (amh *artifactManifestHandler) verifyManifest(ctx context.Context, dm Deser
 	if dm.ArtifactType() == "" {
 		errs = append(errs, distribution.ErrManifestVerification{errors.New("artifactType invalid")})
 	}
-
+	// TODO: check that media type exists
 	if !skipDependencyVerification {
 		bs := amh.repository.Blobs(ctx)
 

--- a/registry/extension/oras/artifactmanifesthandler_test.go
+++ b/registry/extension/oras/artifactmanifesthandler_test.go
@@ -1,0 +1,237 @@
+package oras
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/manifest"
+	"github.com/distribution/distribution/v3/manifest/schema2"
+	"github.com/distribution/distribution/v3/reference"
+	"github.com/distribution/distribution/v3/registry/extension"
+	storage "github.com/distribution/distribution/v3/registry/storage"
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
+	"github.com/opencontainers/go-digest"
+	orasartifacts "github.com/oras-project/artifacts-spec/specs-go/v1"
+)
+
+func createRegistry(t *testing.T, driver driver.StorageDriver, options ...storage.RegistryOption) distribution.Namespace {
+	ctx := context.Background()
+	options = append([]storage.RegistryOption{storage.EnableDelete}, options...)
+	extensionConfig := OrasOptions{
+		ArtifactsExtComponents: []string{"referrers"},
+	}
+	ns, err := extension.Get(ctx, "oras", driver, extensionConfig)
+	if err != nil {
+		t.Fatalf("unable to configure extension namespace (%s): %s", "oras", err)
+	}
+	options = append(options, storage.AddExtendedStorage(ns))
+	registry, err := storage.NewRegistry(ctx, driver, options...)
+	if err != nil {
+		t.Fatalf("failed to construct namespace")
+	}
+	return registry
+}
+
+func makeRepository(t *testing.T, registry distribution.Namespace, name string) distribution.Repository {
+	ctx := context.Background()
+	named, err := reference.WithName(name)
+	if err != nil {
+		t.Fatalf("failed to parse name %s:  %v", name, err)
+	}
+
+	repo, err := registry.Repository(ctx, named)
+	if err != nil {
+		t.Fatalf("failed to construct repository: %v", err)
+	}
+	return repo
+}
+
+func makeManifestService(t *testing.T, repository distribution.Repository) distribution.ManifestService {
+	ctx := context.Background()
+
+	manifestService, err := repository.Manifests(ctx)
+	if err != nil {
+		t.Fatalf("failed to construct manifest store: %v", err)
+	}
+	return manifestService
+}
+
+func TestVerifyArtifactManifestPut(t *testing.T) {
+	ctx := context.Background()
+	inmemoryDriver := inmemory.New()
+	registry := createRegistry(t, inmemoryDriver)
+	repo := makeRepository(t, registry, "test")
+	manifestService := makeManifestService(t, repo)
+
+	artifactBlob, err := repo.Blobs(ctx).Put(ctx, orasartifacts.MediaTypeDescriptor, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := repo.Blobs(ctx).Put(ctx, schema2.MediaTypeImageConfig, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	layer, err := repo.Blobs(ctx).Put(ctx, schema2.MediaTypeLayer, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subjectManifest := schema2.Manifest{
+		Versioned: manifest.Versioned{
+			SchemaVersion: 2,
+			MediaType:     schema2.MediaTypeManifest,
+		},
+		Config: config,
+		Layers: []distribution.Descriptor{
+			layer,
+		},
+	}
+
+	dm, err := schema2.FromStruct(subjectManifest)
+	if err != nil {
+		t.Fatalf("failed to marshal subject manifest: %v", err)
+	}
+	_, dmPayload, err := dm.Payload()
+	if err != nil {
+		t.Fatalf("failed to get subject manifest payload: %v", err)
+	}
+
+	dg, err := manifestService.Put(ctx, dm)
+	if err != nil {
+		t.Fatalf("failed to put subject manifest with err: %v", err)
+	}
+
+	artifactBlobDescriptor := orasartifacts.Descriptor{
+		MediaType: artifactBlob.MediaType,
+		Digest:    artifactBlob.Digest,
+		Size:      artifactBlob.Size,
+	}
+
+	template := Manifest{
+		inner: orasartifacts.Manifest{
+			MediaType:    orasartifacts.MediaTypeArtifactManifest,
+			ArtifactType: "test_artifactType",
+			Blobs: []orasartifacts.Descriptor{
+				artifactBlobDescriptor,
+			},
+			Subject: orasartifacts.Descriptor{
+				MediaType: dm.MediaType,
+				Size:      int64(len(dmPayload)),
+				Digest:    dg,
+			},
+			Annotations: map[string]string{
+				createAnnotationName: "2022-04-22T17:03:05-07:00",
+			},
+		},
+	}
+
+	type testcase struct {
+		MediaType    string
+		ArtifactType string
+		Blobs        []orasartifacts.Descriptor
+		Subject      orasartifacts.Descriptor
+		Annotations  map[string]string
+		Err          error
+	}
+
+	cases := []testcase{
+		{
+			orasartifacts.MediaTypeArtifactManifest,
+			template.inner.ArtifactType,
+			template.inner.Blobs,
+			template.inner.Subject,
+			template.Annotations(),
+			nil,
+		},
+		// non oras artifact manifest media type
+		{
+			"wrongMediaType",
+			template.inner.ArtifactType,
+			template.inner.Blobs,
+			template.inner.Subject,
+			template.Annotations(),
+			errInvalidMediaType,
+		},
+		// empty artifactType
+		{
+			orasartifacts.MediaTypeArtifactManifest,
+			"",
+			template.inner.Blobs,
+			template.inner.Subject,
+			template.Annotations(),
+			errInvalidArtifactType,
+		},
+		// invalid subject
+		{
+			orasartifacts.MediaTypeArtifactManifest,
+			template.inner.ArtifactType,
+			template.inner.Blobs,
+			orasartifacts.Descriptor{
+				MediaType: dm.MediaType,
+				Size:      int64(len(dmPayload)),
+				Digest:    digest.FromString("sha256:invalid"),
+			},
+			template.Annotations(),
+			distribution.ErrManifestBlobUnknown{Digest: digest.FromString("sha256:invalid")},
+		},
+		// invalid created annotation
+		{
+			orasartifacts.MediaTypeArtifactManifest,
+			template.inner.ArtifactType,
+			template.inner.Blobs,
+			template.inner.Subject,
+			map[string]string{
+				createAnnotationName: "invalid_timestamp",
+			},
+			errInvalidCreatedAnnotation,
+		},
+		// invalid blob
+		{
+			orasartifacts.MediaTypeArtifactManifest,
+			template.inner.ArtifactType,
+			[]orasartifacts.Descriptor{
+				{
+					MediaType: artifactBlob.MediaType,
+					Digest:    digest.FromString("sha256:invalid_blob_digest"),
+					Size:      artifactBlob.Size,
+				},
+			},
+			template.inner.Subject,
+			template.Annotations(),
+			distribution.ErrManifestBlobUnknown{Digest: digest.FromString("sha256:invalid_blob_digest")},
+		},
+	}
+
+	for _, c := range cases {
+		manifest := Manifest{
+			inner: orasartifacts.Manifest{
+				MediaType:    c.MediaType,
+				ArtifactType: c.ArtifactType,
+				Blobs:        c.Blobs,
+				Subject:      c.Subject,
+				Annotations:  c.Annotations,
+			},
+		}
+
+		marshalledManifest, err := json.Marshal(manifest.inner)
+		if err != nil {
+			t.Fatalf("failed to marshal manifest: %v", err)
+		}
+
+		_, err = manifestService.Put(ctx, &DeserializedManifest{
+			Manifest: manifest,
+			raw:      marshalledManifest,
+		})
+		if verr, ok := err.(distribution.ErrManifestVerification); ok {
+			err = verr[0]
+		}
+		if err != c.Err {
+			t.Errorf("expected %v, got %v", c.Err, err)
+		}
+	}
+}

--- a/registry/extension/oras/artifactservice.go
+++ b/registry/extension/oras/artifactservice.go
@@ -28,6 +28,7 @@ type referrersHandler struct {
 }
 
 const createAnnotationName = "io.cncf.oras.artifact.created"
+const createAnnotationTimestampFormat = time.RFC3339
 
 func (h *referrersHandler) Referrers(ctx context.Context, revision digest.Digest, artifactType string) ([]artifactv1.Descriptor, error) {
 	dcontext.GetLogger(ctx).Debug("(*manifestStore).Referrers")
@@ -91,8 +92,8 @@ func (h *referrersHandler) Referrers(ctx context.Context, revision digest.Digest
 
 	// sort the list of descriptors that contain the created annotation
 	sort.Slice(referrersSorted, func(i, j int) bool {
-		firstElem, _ := time.Parse(time.RFC3339, referrersSorted[i].Annotations[createAnnotationName])
-		secondElem, _ := time.Parse(time.RFC3339, referrersSorted[j].Annotations[createAnnotationName])
+		firstElem, _ := time.Parse(createAnnotationTimestampFormat, referrersSorted[i].Annotations[createAnnotationName])
+		secondElem, _ := time.Parse(createAnnotationTimestampFormat, referrersSorted[j].Annotations[createAnnotationName])
 		// most recent artifact first
 		return firstElem.After(secondElem)
 	})

--- a/registry/extension/oras/artifactservice.go
+++ b/registry/extension/oras/artifactservice.go
@@ -29,7 +29,7 @@ type referrersHandler struct {
 
 const createAnnotationName = "io.cncf.oras.artifact.created"
 
-func (h *referrersHandler) Referrers(ctx context.Context, revision digest.Digest, referrerType string) ([]artifactv1.Descriptor, error) {
+func (h *referrersHandler) Referrers(ctx context.Context, revision digest.Digest, artifactType string) ([]artifactv1.Descriptor, error) {
 	dcontext.GetLogger(ctx).Debug("(*manifestStore).Referrers")
 
 	var referrersUnsorted []artifactv1.Descriptor
@@ -55,8 +55,10 @@ func (h *referrersHandler) Referrers(ctx context.Context, revision digest.Digest
 			return nil
 		}
 
-		// filtering by artifact type
-		if ArtifactMan.ArtifactType() == referrerType {
+		extractedArtifactType := ArtifactMan.ArtifactType()
+
+		// filtering by artifact type or bypass if no artifact type specified
+		if artifactType == "" || extractedArtifactType == artifactType {
 			desc, err := blobStatter.Stat(ctx, referrerRevision)
 			if err != nil {
 				return err
@@ -66,7 +68,7 @@ func (h *referrersHandler) Referrers(ctx context.Context, revision digest.Digest
 				MediaType:    desc.MediaType,
 				Size:         desc.Size,
 				Digest:       desc.Digest,
-				ArtifactType: ArtifactMan.ArtifactType(),
+				ArtifactType: extractedArtifactType,
 				Annotations:  ArtifactMan.Annotations(),
 			}
 

--- a/registry/extension/oras/referrers.go
+++ b/registry/extension/oras/referrers.go
@@ -13,7 +13,7 @@ import (
 
 // referrersResponse describes the response body of the referrers API.
 type referrersResponse struct {
-	Referrers []orasartifacts.Descriptor `json:"references"`
+	Referrers []orasartifacts.Descriptor `json:"referrers"`
 }
 
 func (h *referrersHandler) getReferrers(w http.ResponseWriter, r *http.Request) {

--- a/registry/extension/oras/referrers.go
+++ b/registry/extension/oras/referrers.go
@@ -21,7 +21,7 @@ type ReferrersResponse struct {
 	Referrers []orasartifacts.Descriptor `json:"referrers"`
 }
 
-const maxPageSize = 50
+const maxPageSize = 100
 
 // minimum page size used for # of digests to put in nextToken
 const minPageSize = 3

--- a/registry/extension/oras/referrers.go
+++ b/registry/extension/oras/referrers.go
@@ -15,8 +15,8 @@ import (
 	orasartifacts "github.com/oras-project/artifacts-spec/specs-go/v1"
 )
 
-// referrersResponse describes the response body of the referrers API.
-type referrersResponse struct {
+// ReferrersResponse describes the response body of the referrers API.
+type ReferrersResponse struct {
 	Referrers []orasartifacts.Descriptor `json:"referrers"`
 }
 
@@ -94,17 +94,17 @@ func (h *referrersHandler) getReferrers(w http.ResponseWriter, r *http.Request) 
 			referrers = referrers[startIndex:]
 		} else {
 			referrers = referrers[startIndex:(startIndex + nPage)]
-			var nextDgsts []string
 			// generate string list of digests for nextToken
-			for _, ref := range referrers[nPage-minPageSize:] {
-				nextDgsts = append(nextDgsts, ref.Digest.String())
+			var nextDgsts []string
+			for i := nPage - 1; i >= nPage-minPageSize; i-- {
+				nextDgsts = append(nextDgsts, referrers[i].Digest.String())
 			}
 			// add the Link Header
 			w.Header().Set("Link", generateLinkHeader(h.extContext.Repository.Named().Name(), h.Digest.String(), artifactType, nextDgsts, nPage))
 		}
 	}
 
-	response := referrersResponse{
+	response := ReferrersResponse{
 		Referrers: referrers,
 	}
 

--- a/registry/extension/oras/referrers.go
+++ b/registry/extension/oras/referrers.go
@@ -2,12 +2,15 @@ package oras
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/distribution/distribution/v3"
 	dcontext "github.com/distribution/distribution/v3/context"
 	"github.com/distribution/distribution/v3/registry/api/errcode"
 	v2 "github.com/distribution/distribution/v3/registry/api/v2"
+	"github.com/opencontainers/go-digest"
 	orasartifacts "github.com/oras-project/artifacts-spec/specs-go/v1"
 )
 
@@ -16,11 +19,25 @@ type referrersResponse struct {
 	Referrers []orasartifacts.Descriptor `json:"referrers"`
 }
 
+const maxPageSize = 50
+
 func (h *referrersHandler) getReferrers(w http.ResponseWriter, r *http.Request) {
 	dcontext.GetLogger(h.extContext).Debug("Get")
 
 	// This can be empty
 	artifactType := r.FormValue("artifactType")
+	nPage, err := strconv.Atoi(r.FormValue("n"))
+	if nPage < 0 || err != nil {
+		nPage = maxPageSize
+	}
+	nextToken := r.FormValue("nextToken")
+	if nextToken != "" {
+		_, err = digest.Parse(nextToken)
+		if err != nil {
+			h.extContext.Errors = append(h.extContext.Errors, v2.ErrorCodeDigestInvalid.WithDetail("nextToken digest parsing failed"))
+			return
+		}
+	}
 
 	if h.Digest == "" {
 		h.extContext.Errors = append(h.extContext.Errors, v2.ErrorCodeManifestUnknown.WithDetail("digest not specified"))
@@ -41,6 +58,37 @@ func (h *referrersHandler) getReferrers(w http.ResponseWriter, r *http.Request) 
 		referrers = []orasartifacts.Descriptor{}
 	}
 
+	// only consider pagination if # of referrers is greater than page size
+	if len(referrers) > nPage {
+		startIndex := 0
+		if nextToken != "" {
+			for i, ref := range referrers {
+				if ref.Digest.String() == nextToken {
+					startIndex = i + 1
+				}
+			}
+			// if matching referrer not found
+			if startIndex == 0 {
+				h.extContext.Errors = append(h.extContext.Errors, v2.ErrorCodeReferrerNotFound.WithDetail("matching referrer with digest in nextToken not found"))
+				return
+			}
+		}
+
+		// only applicable if last item provided as nextToken
+		if startIndex == len(referrers) {
+			referrers = []orasartifacts.Descriptor{}
+		}
+
+		// if there's only 1 page of results left
+		if len(referrers)-startIndex <= nPage {
+			referrers = referrers[startIndex:]
+		} else {
+			referrers = referrers[startIndex:(startIndex + nPage)]
+			// add the Link Header
+			w.Header().Set("Link", generateLinkHeader(h.extContext.Repository.Named().Name(), h.Digest.String(), artifactType, referrers[nPage-1].Digest.String(), nPage))
+		}
+	}
+
 	response := referrersResponse{
 		Referrers: referrers,
 	}
@@ -52,4 +100,14 @@ func (h *referrersHandler) getReferrers(w http.ResponseWriter, r *http.Request) 
 		h.extContext.Errors = append(h.extContext.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 		return
 	}
+}
+
+func generateLinkHeader(repoName, subjectDigest, artifactType, lastDigest string, nPage int) string {
+	url := fmt.Sprintf("/v2/%s/_oras/artifacts/referrers?digest=%s&artifactType=%s&n=%d&nextToken=%s",
+		repoName,
+		subjectDigest,
+		artifactType,
+		nPage,
+		lastDigest)
+	return fmt.Sprintf("<%s>; rel=\"next\"", url)
 }

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1553,8 +1554,13 @@ func setupReferrersTests(t *testing.T, env *testEnv, imageNameRef reference.Name
 }
 
 func checkReferrersLink(t *testing.T, urlStr string, numEntries int, nextToken string, subjectName string) url.URL {
+	decodedURLBytes, err := base64.URLEncoding.DecodeString(urlStr)
+	decodedURL := string(decodedURLBytes)
+	if err != nil {
+		t.Fatalf("Base64 decoding failed for nextToken: %v", err)
+	}
 	re := regexp.MustCompile("<(/v2/" + subjectName + "/_oras/artifacts/referrers.*)>; rel=\"next\"")
-	matches := re.FindStringSubmatch(urlStr)
+	matches := re.FindStringSubmatch(decodedURL)
 
 	if len(matches) != 2 {
 		t.Fatalf("Referrer link address response was incorrect")

--- a/registry/handlers/api_test.go
+++ b/registry/handlers/api_test.go
@@ -1298,6 +1298,8 @@ func testReferrersPagination(t *testing.T, env *testEnv,
 
 	// generates expected nextToken based on oldest 3 digests returned
 	expectedNextToken := fmt.Sprintf("%s,%s,%s", expectedDigests[digestIndexOrder[3]], expectedDigests[digestIndexOrder[2]], expectedDigests[digestIndexOrder[1]])
+	// base64 encode expected next token
+	expectedNextToken = base64.RawURLEncoding.EncodeToString([]byte(expectedNextToken))
 	// check Link has correct query parameters and return nextToken link
 	linkURL := checkReferrersLink(t, link, nPage, expectedNextToken, subjectManifestName)
 	// use nextToken link to generate absolute URL for next page request
@@ -1509,13 +1511,8 @@ func TestReferrers(t *testing.T) {
 }
 
 func checkReferrersLink(t *testing.T, urlStr string, numEntries int, nextToken string, subjectName string) url.URL {
-	decodedURLBytes, err := base64.URLEncoding.DecodeString(urlStr)
-	decodedURL := string(decodedURLBytes)
-	if err != nil {
-		t.Fatalf("Base64 decoding failed for nextToken: %v", err)
-	}
 	re := regexp.MustCompile("<(/v2/" + subjectName + "/_oras/artifacts/referrers.*)>; rel=\"next\"")
-	matches := re.FindStringSubmatch(decodedURL)
+	matches := re.FindStringSubmatch(urlStr)
 
 	if len(matches) != 2 {
 		t.Fatalf("Referrer link address response was incorrect")

--- a/vendor/github.com/oras-project/artifacts-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/oras-project/artifacts-spec/specs-go/v1/manifest.go
@@ -17,6 +17,9 @@ package v1
 // Manifest describes an ORAS artifact.
 // This structure provides `application/vnd.oras.artifact.manifest.v1+json` mediatype when marshalled to JSON.
 type Manifest struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType"`
+
 	// ArtifactType is the artifact type of the object this schema refers to.
 	ArtifactType string `json:"artifactType"`
 

--- a/vendor/github.com/oras-project/artifacts-spec/specs-go/v1/mediatype.go
+++ b/vendor/github.com/oras-project/artifacts-spec/specs-go/v1/mediatype.go
@@ -15,6 +15,9 @@
 package v1
 
 const (
+	// MediaTypeDescriptor specifies the media type for a content descriptor.
+	MediaTypeDescriptor = "application/vnd.cncf.oras.artifact.descriptor.v1+json"
+
 	// MediaTypeArtifactManifest specifies the media type for an ORAS artifact reference type manifest.
 	MediaTypeArtifactManifest = "application/vnd.cncf.oras.artifact.manifest.v1+json"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -153,7 +153,7 @@ github.com/opencontainers/go-digest
 ## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/oras-project/artifacts-spec v1.0.0-draft.1
+# github.com/oras-project/artifacts-spec v1.0.0-rc.1
 ## explicit
 github.com/oras-project/artifacts-spec/specs-go/v1
 # github.com/prometheus/client_golang v1.1.0


### PR DESCRIPTION
- Updates artifact spec to RC1
- Implements sorting
- Implements filtering
- Implements registry level OCI discover
- Implements repository level OCI discover
- Implements pagination
- Adds tests for artifact manifest handler
- Adds tests for referrers API

References #4 