### PR TITLE
Update Discover Response Name and Description

### DIFF
--- a/registry/extension/distribution/registry.go
+++ b/registry/extension/distribution/registry.go
@@ -110,7 +110,7 @@ func (d *distributionNamespace) GetRepositoryRoutes() []extension.Route {
 				Methods: []v2.MethodDescriptor{
 					{
 						Method:      "GET",
-						Description: "Get a set of digests that the specified tag historically pointed to",
+						Description: "get a set of digests that the specified tag historically pointed to",
 						Requests: []v2.RequestDescriptor{
 							{
 								QueryParameters: []v2.ParameterDescriptor{

--- a/registry/extension/distribution/registry.go
+++ b/registry/extension/distribution/registry.go
@@ -20,7 +20,7 @@ const (
 	manifestsComponentName  = "manifests"
 	tagHistoryComponentName = "taghistory"
 	namespaceUrl            = "insert link"
-	namespaceDescription    = "distribution extension adds tag history and manifest list functionality"
+	namespaceDescription    = "distribution extension adds tag history and manifest list functionality."
 )
 
 type distributionNamespace struct {
@@ -86,7 +86,8 @@ func (d *distributionNamespace) GetRepositoryRoutes() []extension.Route {
 			Extension: extensionName,
 			Component: manifestsComponentName,
 			Descriptor: v2.RouteDescriptor{
-				Entity: "Manifest",
+				Entity:      "Manifest",
+				Description: "returns all manifest digests for a repository",
 				Methods: []v2.MethodDescriptor{
 					{
 						Method:      "GET",
@@ -104,7 +105,8 @@ func (d *distributionNamespace) GetRepositoryRoutes() []extension.Route {
 			Extension: extensionName,
 			Component: tagHistoryComponentName,
 			Descriptor: v2.RouteDescriptor{
-				Entity: "TagHistory",
+				Entity:      "TagHistory",
+				Description: "returns digests that previously specified a tag",
 				Methods: []v2.MethodDescriptor{
 					{
 						Method:      "GET",

--- a/registry/extension/extension.go
+++ b/registry/extension/extension.go
@@ -74,7 +74,7 @@ var extensionsNamespaces map[string]Namespace
 func EnumerateRegistered(ctx Context) (enumeratedExtensions []EnumerateExtension) {
 	for _, namespace := range extensionsNamespaces {
 		enumerateExtension := EnumerateExtension{
-			Name:        namespace.GetNamespaceName(),
+			Name:        fmt.Sprintf("_%s", namespace.GetNamespaceName()),
 			Url:         namespace.GetNamespaceUrl(),
 			Description: namespace.GetNamespaceDescription(),
 			Endpoints:   []string{},
@@ -90,6 +90,7 @@ func EnumerateRegistered(ctx Context) (enumeratedExtensions []EnumerateExtension
 		for _, route := range scopedRoutes {
 			path := fmt.Sprintf("_%s/%s/%s", route.Namespace, route.Extension, route.Component)
 			enumerateExtension.Endpoints = append(enumerateExtension.Endpoints, path)
+			enumerateExtension.Description = fmt.Sprintf("%s %s %s.", enumerateExtension.Description, path, route.Descriptor.Description)
 		}
 
 		// add extension to list if endpoints exist

--- a/registry/extension/oci/discover.go
+++ b/registry/extension/oci/discover.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/distribution/distribution/v3/registry/api/errcode"
@@ -29,7 +30,7 @@ func (eh *extensionHandler) getExtensions(w http.ResponseWriter, r *http.Request
 
 	// remove the oci extension so it's not returned by discover
 	for i, e := range enumeratedExtensions {
-		if e.Name == namespaceName {
+		if e.Name == fmt.Sprintf("_%s", namespaceName) {
 			enumeratedExtensions = append(enumeratedExtensions[:i], enumeratedExtensions[i+1:]...)
 		}
 	}

--- a/registry/extension/oci/discover.go
+++ b/registry/extension/oci/discover.go
@@ -29,8 +29,9 @@ func (eh *extensionHandler) getExtensions(w http.ResponseWriter, r *http.Request
 	enumeratedExtensions := extension.EnumerateRegistered(*eh.Context)
 
 	// remove the oci extension so it's not returned by discover
+	ociExtensionName := fmt.Sprintf("_%s", namespaceName)
 	for i, e := range enumeratedExtensions {
-		if e.Name == fmt.Sprintf("_%s", namespaceName) {
+		if e.Name == ociExtensionName {
 			enumeratedExtensions = append(enumeratedExtensions[:i], enumeratedExtensions[i+1:]...)
 		}
 	}

--- a/registry/extension/oci/oci.go
+++ b/registry/extension/oci/oci.go
@@ -84,7 +84,7 @@ func (o *ociNamespace) GetRepositoryRoutes() []extension.Route {
 				Methods: []v2.MethodDescriptor{
 					{
 						Method:      "GET",
-						Description: "Get all extensions enabled for a repository.",
+						Description: "get all extensions enabled for a repository.",
 					},
 				},
 			},
@@ -106,11 +106,11 @@ func (o *ociNamespace) GetRegistryRoutes() []extension.Route {
 			Component: discoverComponentName,
 			Descriptor: v2.RouteDescriptor{
 				Entity:      "Extension",
-				Description: "discovers extensions enabled at the repository level",
+				Description: "discovers extensions enabled at the registry level",
 				Methods: []v2.MethodDescriptor{
 					{
 						Method:      "GET",
-						Description: "Get all extensions enabled for a registry.",
+						Description: "get all extensions enabled for a registry.",
 					},
 				},
 			},

--- a/registry/extension/oci/oci.go
+++ b/registry/extension/oci/oci.go
@@ -19,7 +19,7 @@ const (
 	extensionName         = "ext"
 	discoverComponentName = "discover"
 	namespaceUrl          = "https://github.com/opencontainers/distribution-spec/blob/main/extensions/_oci.md"
-	namespaceDescription  = "oci extension enables listing of supported registry and repository extensions"
+	namespaceDescription  = "oci extension enables listing of supported registry and repository extensions."
 )
 
 type ociNamespace struct {
@@ -79,7 +79,8 @@ func (o *ociNamespace) GetRepositoryRoutes() []extension.Route {
 			Extension: extensionName,
 			Component: discoverComponentName,
 			Descriptor: v2.RouteDescriptor{
-				Entity: "Extension",
+				Entity:      "Extension",
+				Description: "discovers extensions enabled at the repository level",
 				Methods: []v2.MethodDescriptor{
 					{
 						Method:      "GET",
@@ -104,7 +105,8 @@ func (o *ociNamespace) GetRegistryRoutes() []extension.Route {
 			Extension: extensionName,
 			Component: discoverComponentName,
 			Descriptor: v2.RouteDescriptor{
-				Entity: "Extension",
+				Entity:      "Extension",
+				Description: "discovers extensions enabled at the repository level",
 				Methods: []v2.MethodDescriptor{
 					{
 						Method:      "GET",

--- a/registry/extension/oras/oras.go
+++ b/registry/extension/oras/oras.go
@@ -21,7 +21,7 @@ const (
 	extensionName          = "artifacts"
 	referrersComponentName = "referrers"
 	namespaceUrl           = "https://github.com/oras-project/artifacts-spec/blob/main/manifest-referrers-api.md"
-	namespaceDescription   = "oras extension enables listing of all reference artifacts associated with subject"
+	namespaceDescription   = "oras extension enables listing of all reference artifacts associated with subject."
 )
 
 type orasNamespace struct {
@@ -88,11 +88,12 @@ func (d *orasNamespace) GetRepositoryRoutes() []extension.Route {
 			Extension: extensionName,
 			Component: referrersComponentName,
 			Descriptor: v2.RouteDescriptor{
-				Entity: "Referrers",
+				Entity:      "Referrers",
+				Description: "returns all referrers for a given digest",
 				Methods: []v2.MethodDescriptor{
 					{
 						Method:      "GET",
-						Description: "Get all referrers for the given digest. Currently the API doesn't support pagination.",
+						Description: "Get all referrers for the given digest ",
 					},
 				},
 			},

--- a/registry/extension/oras/oras.go
+++ b/registry/extension/oras/oras.go
@@ -21,7 +21,7 @@ const (
 	extensionName          = "artifacts"
 	referrersComponentName = "referrers"
 	namespaceUrl           = "https://github.com/oras-project/artifacts-spec/blob/main/manifest-referrers-api.md"
-	namespaceDescription   = "oras extension enables listing of all reference artifacts associated with subject."
+	namespaceDescription   = "ORAS referrers listing API."
 )
 
 type orasNamespace struct {
@@ -93,7 +93,7 @@ func (d *orasNamespace) GetRepositoryRoutes() []extension.Route {
 				Methods: []v2.MethodDescriptor{
 					{
 						Method:      "GET",
-						Description: "Get all referrers for the given digest",
+						Description: "get all referrers for the given digest",
 					},
 				},
 			},

--- a/registry/extension/oras/oras.go
+++ b/registry/extension/oras/oras.go
@@ -93,7 +93,7 @@ func (d *orasNamespace) GetRepositoryRoutes() []extension.Route {
 				Methods: []v2.MethodDescriptor{
 					{
 						Method:      "GET",
-						Description: "Get all referrers for the given digest ",
+						Description: "Get all referrers for the given digest",
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Akash Singhal <akashsinghal@microsoft.com>

- Updates discover response so extension name follows distribution spec: adds `_` before namespace name 
- Changes description filed in discover response so it contains individual descriptions of each endpoint returned