### PR TITLE
refactor: rename "manifest/ocischema/manifest.go" to "image_manifest.go"

### DIFF
--- a/manifest/manifestlist/manifestlist_test.go
+++ b/manifest/manifestlist/manifestlist_test.go
@@ -331,7 +331,7 @@ func TestMediaTypes(t *testing.T) {
 }
 
 func TestValidateManifest(t *testing.T) {
-	manifest := ocischema.Manifest{
+	manifest := ocischema.ImageManifest{
 		Config: distribution.Descriptor{Size: 1},
 		Layers: []distribution.Descriptor{{Size: 2}},
 	}

--- a/manifest/ocischema/builder.go
+++ b/manifest/ocischema/builder.go
@@ -57,7 +57,7 @@ func (mb *Builder) SetMediaType(mediaType string) error {
 
 // Build produces a final manifest from the given references.
 func (mb *Builder) Build(ctx context.Context) (distribution.Manifest, error) {
-	m := Manifest{
+	m := ImageManifest{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 2,
 			MediaType:     mb.mediaType,
@@ -76,7 +76,7 @@ func (mb *Builder) Build(ctx context.Context) (distribution.Manifest, error) {
 		// Override MediaType, since Put always replaces the specified media
 		// type with application/octet-stream in the descriptor it returns.
 		m.Config.MediaType = v1.MediaTypeImageConfig
-		return FromStruct(m)
+		return ImageManifestFromStruct(m)
 	case distribution.ErrBlobUnknown:
 		// nop
 	default:
@@ -92,7 +92,7 @@ func (mb *Builder) Build(ctx context.Context) (distribution.Manifest, error) {
 		return nil, err
 	}
 
-	return FromStruct(m)
+	return ImageManifestFromStruct(m)
 }
 
 // AppendReference adds a reference to the current ManifestBuilder.

--- a/manifest/ocischema/builder_test.go
+++ b/manifest/ocischema/builder_test.go
@@ -145,7 +145,7 @@ func TestBuilder(t *testing.T) {
 		t.Fatal("config was not put in the blob store")
 	}
 
-	manifest := built.(*DeserializedManifest).Manifest
+	manifest := built.(*DeserializedImageManifest).ImageManifest
 	if manifest.Annotations["hot"] != "potato" {
 		t.Fatalf("unexpected annotation in manifest: %s", manifest.Annotations["hot"])
 	}

--- a/manifest/ocischema/image_manifest.go
+++ b/manifest/ocischema/image_manifest.go
@@ -21,11 +21,11 @@ var (
 )
 
 func init() {
-	ocischemaFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
-		if err := validateManifest(b); err != nil {
+	ociImageFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
+		if err := validateImageManifest(b); err != nil {
 			return nil, distribution.Descriptor{}, err
 		}
-		m := new(DeserializedManifest)
+		m := new(DeserializedImageManifest)
 		err := m.UnmarshalJSON(b)
 		if err != nil {
 			return nil, distribution.Descriptor{}, err
@@ -34,14 +34,14 @@ func init() {
 		dgst := digest.FromBytes(b)
 		return m, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: v1.MediaTypeImageManifest}, err
 	}
-	err := distribution.RegisterManifestSchema(v1.MediaTypeImageManifest, ocischemaFunc)
+	err := distribution.RegisterManifestSchema(v1.MediaTypeImageManifest, ociImageFunc)
 	if err != nil {
-		panic(fmt.Sprintf("Unable to register manifest: %s", err))
+		panic(fmt.Sprintf("Unable to register image manifest: %s", err))
 	}
 }
 
-// Manifest defines a ocischema manifest.
-type Manifest struct {
+// ImageManifest defines a ocischema image manifest.
+type ImageManifest struct {
 	manifest.Versioned
 
 	// Config references the image configuration as a blob.
@@ -56,7 +56,7 @@ type Manifest struct {
 }
 
 // References returns the descriptors of this manifests references.
-func (m Manifest) References() []distribution.Descriptor {
+func (m ImageManifest) References() []distribution.Descriptor {
 	references := make([]distribution.Descriptor, 0, 1+len(m.Layers))
 	references = append(references, m.Config)
 	references = append(references, m.Layers...)
@@ -64,65 +64,65 @@ func (m Manifest) References() []distribution.Descriptor {
 }
 
 // Target returns the target of this manifest.
-func (m Manifest) Target() distribution.Descriptor {
+func (m ImageManifest) Target() distribution.Descriptor {
 	return m.Config
 }
 
-// DeserializedManifest wraps Manifest with a copy of the original JSON.
+// DeserializedImageManifest wraps ImageManifest with a copy of the original JSON.
 // It satisfies the distribution.Manifest interface.
-type DeserializedManifest struct {
-	Manifest
+type DeserializedImageManifest struct {
+	ImageManifest
 
-	// canonical is the canonical byte representation of the Manifest.
+	// canonical is the canonical byte representation of the ImageManifest.
 	canonical []byte
 }
 
-// FromStruct takes a Manifest structure, marshals it to JSON, and returns a
-// DeserializedManifest which contains the manifest and its JSON representation.
-func FromStruct(m Manifest) (*DeserializedManifest, error) {
-	var deserialized DeserializedManifest
-	deserialized.Manifest = m
+// ImageManifestFromStruct takes an ImageManifest structure, marshals it to JSON, and returns a
+// DeserializedImageManifest which contains the manifest and its JSON representation.
+func ImageManifestFromStruct(m ImageManifest) (*DeserializedImageManifest, error) {
+	var deserialized DeserializedImageManifest
+	deserialized.ImageManifest = m
 
 	var err error
 	deserialized.canonical, err = json.MarshalIndent(&m, "", "   ")
 	return &deserialized, err
 }
 
-// UnmarshalJSON populates a new Manifest struct from JSON data.
-func (m *DeserializedManifest) UnmarshalJSON(b []byte) error {
+// UnmarshalJSON populates a new ImageManifest struct from JSON data.
+func (m *DeserializedImageManifest) UnmarshalJSON(b []byte) error {
 	m.canonical = make([]byte, len(b))
 	// store manifest in canonical
 	copy(m.canonical, b)
 
-	// Unmarshal canonical JSON into Manifest object
-	var manifest Manifest
+	// Unmarshal canonical JSON into ImageManifest object
+	var manifest ImageManifest
 	if err := json.Unmarshal(m.canonical, &manifest); err != nil {
 		return err
 	}
 
 	if manifest.MediaType != "" && manifest.MediaType != v1.MediaTypeImageManifest {
-		return fmt.Errorf("if present, mediaType in manifest should be '%s' not '%s'",
+		return fmt.Errorf("if present, mediaType in image manifest should be '%s' not '%s'",
 			v1.MediaTypeImageManifest, manifest.MediaType)
 	}
 
-	m.Manifest = manifest
+	m.ImageManifest = manifest
 
 	return nil
 }
 
 // MarshalJSON returns the contents of canonical. If canonical is empty,
 // marshals the inner contents.
-func (m *DeserializedManifest) MarshalJSON() ([]byte, error) {
+func (m *DeserializedImageManifest) MarshalJSON() ([]byte, error) {
 	if len(m.canonical) > 0 {
 		return m.canonical, nil
 	}
 
-	return nil, errors.New("JSON representation not initialized in DeserializedManifest")
+	return nil, errors.New("JSON representation not initialized in DeserializedImageManifest")
 }
 
 // Payload returns the raw content of the manifest. The contents can be used to
 // calculate the content identifier.
-func (m DeserializedManifest) Payload() (string, []byte, error) {
+func (m DeserializedImageManifest) Payload() (string, []byte, error) {
 	return v1.MediaTypeImageManifest, m.canonical, nil
 }
 
@@ -132,15 +132,15 @@ type unknownDocument struct {
 	Manifests interface{} `json:"manifests,omitempty"`
 }
 
-// validateManifest returns an error if the byte slice is invalid JSON or if it
+// validateImageManifest returns an error if the byte slice is invalid JSON or if it
 // contains fields that belong to a index
-func validateManifest(b []byte) error {
+func validateImageManifest(b []byte) error {
 	var doc unknownDocument
 	if err := json.Unmarshal(b, &doc); err != nil {
 		return err
 	}
 	if doc.Manifests != nil {
-		return errors.New("ocimanifest: expected manifest but found index")
+		return errors.New("oci image manifest: expected image manifest but found index")
 	}
 	return nil
 }

--- a/manifest/ocischema/image_manifest_test.go
+++ b/manifest/ocischema/image_manifest_test.go
@@ -13,7 +13,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-var expectedManifestSerialization = []byte(`{
+var expectedImageManifestSerialization = []byte(`{
    "schemaVersion": 2,
    "mediaType": "application/vnd.oci.image.manifest.v1+json",
    "config": {
@@ -39,8 +39,8 @@ var expectedManifestSerialization = []byte(`{
    }
 }`)
 
-func makeTestManifest(mediaType string) Manifest {
-	return Manifest{
+func makeTestImageManifest(mediaType string) ImageManifest {
+	return ImageManifest{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 2,
 			MediaType:     mediaType,
@@ -63,12 +63,12 @@ func makeTestManifest(mediaType string) Manifest {
 	}
 }
 
-func TestManifest(t *testing.T) {
-	manifest := makeTestManifest(v1.MediaTypeImageManifest)
+func TestImageManifest(t *testing.T) {
+	manifest := makeTestImageManifest(v1.MediaTypeImageManifest)
 
-	deserialized, err := FromStruct(manifest)
+	deserialized, err := ImageManifestFromStruct(manifest)
 	if err != nil {
-		t.Fatalf("error creating DeserializedManifest: %v", err)
+		t.Fatalf("error creating DeserializedImageManifest: %v", err)
 	}
 
 	mediaType, canonical, _ := deserialized.Payload()
@@ -88,11 +88,11 @@ func TestManifest(t *testing.T) {
 	}
 
 	// Check that canonical field matches expected value.
-	if !bytes.Equal(expectedManifestSerialization, canonical) {
-		t.Fatalf("manifest bytes not equal: %q != %q", string(canonical), string(expectedManifestSerialization))
+	if !bytes.Equal(expectedImageManifestSerialization, canonical) {
+		t.Fatalf("manifest bytes not equal: %q != %q", string(canonical), string(expectedImageManifestSerialization))
 	}
 
-	var unmarshalled DeserializedManifest
+	var unmarshalled DeserializedImageManifest
 	if err := json.Unmarshal(deserialized.canonical, &unmarshalled); err != nil {
 		t.Fatalf("error unmarshaling manifest: %v", err)
 	}
@@ -143,11 +143,11 @@ func TestManifest(t *testing.T) {
 }
 
 func mediaTypeTest(t *testing.T, mediaType string, shouldError bool) {
-	manifest := makeTestManifest(mediaType)
+	manifest := makeTestImageManifest(mediaType)
 
-	deserialized, err := FromStruct(manifest)
+	deserialized, err := ImageManifestFromStruct(manifest)
 	if err != nil {
-		t.Fatalf("error creating DeserializedManifest: %v", err)
+		t.Fatalf("error creating DeserializedImageManifest: %v", err)
 	}
 
 	unmarshalled, descriptor, err := distribution.UnmarshalManifest(
@@ -163,7 +163,7 @@ func mediaTypeTest(t *testing.T, mediaType string, shouldError bool) {
 			t.Fatalf("error unmarshaling manifest, %v", err)
 		}
 
-		asManifest := unmarshalled.(*DeserializedManifest)
+		asManifest := unmarshalled.(*DeserializedImageManifest)
 		if asManifest.MediaType != mediaType {
 			t.Fatalf("Bad media type '%v' as unmarshalled", asManifest.MediaType)
 		}
@@ -185,8 +185,8 @@ func TestMediaTypes(t *testing.T) {
 	mediaTypeTest(t, v1.MediaTypeImageManifest+"XXX", true)
 }
 
-func TestValidateManifest(t *testing.T) {
-	manifest := Manifest{
+func TestValidateImageManifest(t *testing.T) {
+	manifest := ImageManifest{
 		Config: distribution.Descriptor{Size: 1},
 		Layers: []distribution.Descriptor{{Size: 2}},
 	}
@@ -200,7 +200,7 @@ func TestValidateManifest(t *testing.T) {
 		if err != nil {
 			t.Fatal("unexpected error marshaling manifest", err)
 		}
-		if err := validateManifest(b); err != nil {
+		if err := validateImageManifest(b); err != nil {
 			t.Error("manifest should be valid", err)
 		}
 	})
@@ -209,7 +209,7 @@ func TestValidateManifest(t *testing.T) {
 		if err != nil {
 			t.Fatal("unexpected error marshaling index", err)
 		}
-		if err := validateManifest(b); err == nil {
+		if err := validateImageManifest(b); err == nil {
 			t.Error("index should not be valid")
 		}
 	})

--- a/registry/handlers/manifests.go
+++ b/registry/handlers/manifests.go
@@ -156,7 +156,7 @@ func (imh *manifestHandler) GetManifest(w http.ResponseWriter, r *http.Request) 
 	manifestList, isManifestList := manifest.(*manifestlist.DeserializedManifestList)
 	if isSchema2 {
 		manifestType = manifestSchema2
-	} else if _, isOCImanifest := manifest.(*ocischema.DeserializedManifest); isOCImanifest {
+	} else if _, isOCImanifest := manifest.(*ocischema.DeserializedImageManifest); isOCImanifest {
 		manifestType = ociSchema
 	} else if isManifestList {
 		if manifestList.MediaType == manifestlist.MediaTypeManifestList {
@@ -432,7 +432,7 @@ func (imh *manifestHandler) applyResourcePolicy(manifest distribution.Manifest) 
 		default:
 			return errcode.ErrorCodeDenied.WithMessage("unknown manifest class for " + m.Config.MediaType)
 		}
-	case *ocischema.DeserializedManifest:
+	case *ocischema.DeserializedImageManifest:
 		switch m.Config.MediaType {
 		case v1.MediaTypeImageConfig:
 			class = imageClass

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -134,7 +134,7 @@ func (ms *manifestStore) Put(ctx context.Context, manifest distribution.Manifest
 		return ms.schema1Handler.Put(ctx, manifest, ms.skipDependencyVerification)
 	case *schema2.DeserializedManifest:
 		return ms.schema2Handler.Put(ctx, manifest, ms.skipDependencyVerification)
-	case *ocischema.DeserializedManifest:
+	case *ocischema.DeserializedImageManifest:
 		return ms.ocischemaHandler.Put(ctx, manifest, ms.skipDependencyVerification)
 	case *manifestlist.DeserializedManifestList:
 		return ms.manifestListHandler.Put(ctx, manifest, ms.skipDependencyVerification)

--- a/registry/storage/manifeststore_test.go
+++ b/registry/storage/manifeststore_test.go
@@ -441,17 +441,17 @@ func testOCIManifestStorage(t *testing.T, testname string, includeMediaTypes boo
 
 	// before putting the manifest test for proper handling of SchemaVersion
 
-	if manifest.(*ocischema.DeserializedManifest).Manifest.SchemaVersion != 2 {
+	if manifest.(*ocischema.DeserializedImageManifest).ImageManifest.SchemaVersion != 2 {
 		t.Fatalf("%s: unexpected error generating default version for oci manifest", testname)
 	}
-	manifest.(*ocischema.DeserializedManifest).Manifest.SchemaVersion = 0
+	manifest.(*ocischema.DeserializedImageManifest).ImageManifest.SchemaVersion = 0
 
 	var manifestDigest digest.Digest
 	if manifestDigest, err = ms.Put(ctx, manifest); err != nil {
 		if err.Error() != "unrecognized manifest schema version 0" {
 			t.Fatalf("%s: unexpected error putting manifest: %v", testname, err)
 		}
-		manifest.(*ocischema.DeserializedManifest).Manifest.SchemaVersion = 2
+		manifest.(*ocischema.DeserializedImageManifest).ImageManifest.SchemaVersion = 2
 		if manifestDigest, err = ms.Put(ctx, manifest); err != nil {
 			t.Fatalf("%s: unexpected error putting manifest: %v", testname, err)
 		}
@@ -494,7 +494,7 @@ func testOCIManifestStorage(t *testing.T, testname string, includeMediaTypes boo
 		t.Fatalf("%s: unexpected error fetching manifest: %v", testname, err)
 	}
 
-	fetchedManifest, ok := fromStore.(*ocischema.DeserializedManifest)
+	fetchedManifest, ok := fromStore.(*ocischema.DeserializedImageManifest)
 	if !ok {
 		t.Fatalf("%s: unexpected type for fetched manifest", testname)
 	}

--- a/registry/storage/ocimanifesthandler.go
+++ b/registry/storage/ocimanifesthandler.go
@@ -12,7 +12,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-//ocischemaManifestHandler is a ManifestHandler that covers ocischema manifests.
+// ocischemaManifestHandler is a ManifestHandler that covers ocischema manifests.
 type ocischemaManifestHandler struct {
 	repository   distribution.Repository
 	blobStore    distribution.BlobStore
@@ -25,7 +25,7 @@ var _ ManifestHandler = &ocischemaManifestHandler{}
 func (ms *ocischemaManifestHandler) Unmarshal(ctx context.Context, dgst digest.Digest, content []byte) (distribution.Manifest, error) {
 	dcontext.GetLogger(ms.ctx).Debug("(*ocischemaManifestHandler).Unmarshal")
 
-	m := &ocischema.DeserializedManifest{}
+	m := &ocischema.DeserializedImageManifest{}
 	if err := m.UnmarshalJSON(content); err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func (ms *ocischemaManifestHandler) Unmarshal(ctx context.Context, dgst digest.D
 func (ms *ocischemaManifestHandler) Put(ctx context.Context, manifest distribution.Manifest, skipDependencyVerification bool) (digest.Digest, error) {
 	dcontext.GetLogger(ms.ctx).Debug("(*ocischemaManifestHandler).Put")
 
-	m, ok := manifest.(*ocischema.DeserializedManifest)
+	m, ok := manifest.(*ocischema.DeserializedImageManifest)
 	if !ok {
 		return "", fmt.Errorf("non-ocischema manifest put to ocischemaManifestHandler: %T", manifest)
 	}
@@ -62,11 +62,11 @@ func (ms *ocischemaManifestHandler) Put(ctx context.Context, manifest distributi
 // verifyManifest ensures that the manifest content is valid from the
 // perspective of the registry. As a policy, the registry only tries to store
 // valid content, leaving trust policies of that content up to consumers.
-func (ms *ocischemaManifestHandler) verifyManifest(ctx context.Context, mnfst ocischema.DeserializedManifest, skipDependencyVerification bool) error {
+func (ms *ocischemaManifestHandler) verifyManifest(ctx context.Context, mnfst ocischema.DeserializedImageManifest, skipDependencyVerification bool) error {
 	var errs distribution.ErrManifestVerification
 
-	if mnfst.Manifest.SchemaVersion != 2 {
-		return fmt.Errorf("unrecognized manifest schema version %d", mnfst.Manifest.SchemaVersion)
+	if mnfst.ImageManifest.SchemaVersion != 2 {
+		return fmt.Errorf("unrecognized manifest schema version %d", mnfst.ImageManifest.SchemaVersion)
 	}
 
 	if skipDependencyVerification {

--- a/registry/storage/ocimanifesthandler_test.go
+++ b/registry/storage/ocimanifesthandler_test.go
@@ -48,7 +48,7 @@ func TestVerifyOCIManifestNonDistributableLayer(t *testing.T) {
 		MediaType: v1.MediaTypeImageLayerGzip,
 	}
 
-	template := ocischema.Manifest{
+	template := ocischema.ImageManifest{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 2,
 			MediaType:     v1.MediaTypeImageManifest,
@@ -145,7 +145,7 @@ func TestVerifyOCIManifestNonDistributableLayer(t *testing.T) {
 		l := c.BaseLayer
 		l.URLs = c.URLs
 		m.Layers = []distribution.Descriptor{l}
-		dm, err := ocischema.FromStruct(m)
+		dm, err := ocischema.ImageManifestFromStruct(m)
 		if err != nil {
 			t.Error(err)
 			continue
@@ -188,15 +188,15 @@ func TestVerifyOCIManifestBlobLayerAndConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	template := ocischema.Manifest{
+	template := ocischema.ImageManifest{
 		Versioned: manifest.Versioned{
 			SchemaVersion: 2,
 			MediaType:     v1.MediaTypeImageManifest,
 		},
 	}
 
-	checkFn := func(m ocischema.Manifest, rerr error) {
-		dm, err := ocischema.FromStruct(m)
+	checkFn := func(m ocischema.ImageManifest, rerr error) {
+		dm, err := ocischema.ImageManifestFromStruct(m)
 		if err != nil {
 			t.Error(err)
 			return


### PR DESCRIPTION
To implement `artifact_manifest.go` later, the file `manifest/ocischema/manifest.go` and the structs and functions in it are renamed to reflect the fact that they **only** handle oci image manifests.

Part 2 of Issue #21 

Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>