### PR TITLE
feat: index referrers when pushing manifests

### DIFF
--- a/registry/storage/ociartifactmanifesthandler.go
+++ b/registry/storage/ociartifactmanifesthandler.go
@@ -134,8 +134,5 @@ func (ms *ociArtifactManifestHandler) indexReferrers(ctx context.Context, dm *oc
 	if err != nil {
 		return fmt.Errorf("failed to generate referrers link path for %v", revision)
 	}
-	if err := ms.storageDriver.PutContent(ctx, referrersLinkPath, []byte(revision.String())); err != nil {
-		return err
-	}
-	return nil
+	return ms.storageDriver.PutContent(ctx, referrersLinkPath, []byte(revision.String()))
 }

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -40,6 +40,8 @@ const (
 //					data
 //					startedat
 //					hashstates/<algorithm>/<offset>
+//				-> _referrers/
+//
 //		-> blob/<algorithm>
 //			<split directory content addressable storage>
 //
@@ -69,42 +71,42 @@ const (
 //
 // We cover the path formats implemented by this path mapper below.
 //
-//			Manifests:
+//	Manifests:
 //
-//			manifestRevisionsPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/
-//			manifestRevisionPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/
-//			manifestRevisionLinkPathSpec:  <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/link
+//	manifestRevisionsPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/
+//	manifestRevisionPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/
+//	manifestRevisionLinkPathSpec:  <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/link
 //
-//			Tags:
+//	Tags:
 //
-//			manifestTagsPathSpec:                  <root>/v2/repositories/<name>/_manifests/tags/
-//			manifestTagPathSpec:                   <root>/v2/repositories/<name>/_manifests/tags/<tag>/
-//			manifestTagCurrentPathSpec:            <root>/v2/repositories/<name>/_manifests/tags/<tag>/current/link
-//			manifestTagIndexPathSpec:              <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/
-//			manifestTagIndexEntryPathSpec:         <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/
-//			manifestTagIndexEntryLinkPathSpec:     <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/link
+//	manifestTagsPathSpec:                  <root>/v2/repositories/<name>/_manifests/tags/
+//	manifestTagPathSpec:                   <root>/v2/repositories/<name>/_manifests/tags/<tag>/
+//	manifestTagCurrentPathSpec:            <root>/v2/repositories/<name>/_manifests/tags/<tag>/current/link
+//	manifestTagIndexPathSpec:              <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/
+//	manifestTagIndexEntryPathSpec:         <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/
+//	manifestTagIndexEntryLinkPathSpec:     <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/link
 //
-//			Blobs:
+//	Blobs:
 //
-//			layerLinkPathSpec:            <root>/v2/repositories/<name>/_layers/<algorithm>/<hex digest>/link
-//			layersPathSpec:               <root>/v2/repositories/<name>/_layers
+//	layerLinkPathSpec:            <root>/v2/repositories/<name>/_layers/<algorithm>/<hex digest>/link
+//	layersPathSpec:               <root>/v2/repositories/<name>/_layers
 //
-//			Uploads:
+//	Uploads:
 //
-//			uploadDataPathSpec:             <root>/v2/repositories/<name>/_uploads/<id>/data
-//			uploadStartedAtPathSpec:        <root>/v2/repositories/<name>/_uploads/<id>/startedat
-//			uploadHashStatePathSpec:        <root>/v2/repositories/<name>/_uploads/<id>/hashstates/<algorithm>/<offset>
+//	uploadDataPathSpec:             <root>/v2/repositories/<name>/_uploads/<id>/data
+//	uploadStartedAtPathSpec:        <root>/v2/repositories/<name>/_uploads/<id>/startedat
+//	uploadHashStatePathSpec:        <root>/v2/repositories/<name>/_uploads/<id>/hashstates/<algorithm>/<offset>
 //
-//		    Referrers:
+//	Referrers:
 //
-//	        referrersLinkPathSpec:          <root>/v2/repositories/<name>/_referrers/<algorithm>/<hex digest>/<subject algorithm>/<subject hex digest>/link
+//	referrersLinkPathSpec:          <root>/v2/repositories/<name>/_referrers/subjects/<algorithm>/<hex digest>/<subject algorithm>/<subject hex digest>/link
 //
-//			Blob Store:
+//	Blob Store:
 //
-//			blobsPathSpec:                  <root>/v2/blobs/
-//			blobPathSpec:                   <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>
-//			blobDataPathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
-//			blobMediaTypePathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
+//	blobsPathSpec:                  <root>/v2/blobs/
+//	blobPathSpec:                   <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>
+//	blobDataPathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
+//	blobMediaTypePathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
 //
 // For more information on the semantic meaning of each path and their
 // contents, please see the path spec documentation.
@@ -257,7 +259,9 @@ func pathFor(spec pathSpec) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return path.Join(append(append(append(append(repoPrefix, v.name, "_referrers", "subjects"), revisionComponents...), subjectComponents...), "link")...), nil
+		referrersRootPath := append(repoPrefix, v.name, "_referrers", "subjects")
+		referrersComponentPath := append(append(referrersRootPath, revisionComponents...), subjectComponents...)
+		return path.Join(append(referrersComponentPath, "link")...), nil
 	default:
 		// TODO(sday): This is an internal error. Ensure it doesn't escape (panic?).
 		return "", fmt.Errorf("unknown path spec: %#v", v)

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -23,25 +23,25 @@ const (
 //
 // The path layout in the storage backend is roughly as follows:
 //
-//		<root>/v2
-//			-> repositories/
-// 				-><name>/
-// 					-> _manifests/
-// 						revisions
-//							-> <manifest digest path>
-//								-> link
-// 						tags/<tag>
-//							-> current/link
-// 							-> index
-//								-> <algorithm>/<hex digest>/link
-// 					-> _layers/
-// 						<layer links to blob store>
-// 					-> _uploads/<id>
-// 						data
-// 						startedat
-// 						hashstates/<algorithm>/<offset>
-//			-> blob/<algorithm>
-//				<split directory content addressable storage>
+//	<root>/v2
+//		-> repositories/
+//			-><name>/
+//				-> _manifests/
+//					revisions
+//						-> <manifest digest path>
+//							-> link
+//					tags/<tag>
+//						-> current/link
+//						-> index
+//							-> <algorithm>/<hex digest>/link
+//				-> _layers/
+//					<layer links to blob store>
+//				-> _uploads/<id>
+//					data
+//					startedat
+//					hashstates/<algorithm>/<offset>
+//		-> blob/<algorithm>
+//			<split directory content addressable storage>
 //
 // The storage backend layout is broken up into a content-addressable blob
 // store and repositories. The content-addressable blob store holds most data
@@ -69,38 +69,42 @@ const (
 //
 // We cover the path formats implemented by this path mapper below.
 //
-//	Manifests:
+//			Manifests:
 //
-// 	manifestRevisionsPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/
-// 	manifestRevisionPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/
-// 	manifestRevisionLinkPathSpec:  <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/link
+//			manifestRevisionsPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/
+//			manifestRevisionPathSpec:      <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/
+//			manifestRevisionLinkPathSpec:  <root>/v2/repositories/<name>/_manifests/revisions/<algorithm>/<hex digest>/link
 //
-//	Tags:
+//			Tags:
 //
-// 	manifestTagsPathSpec:                  <root>/v2/repositories/<name>/_manifests/tags/
-// 	manifestTagPathSpec:                   <root>/v2/repositories/<name>/_manifests/tags/<tag>/
-// 	manifestTagCurrentPathSpec:            <root>/v2/repositories/<name>/_manifests/tags/<tag>/current/link
-// 	manifestTagIndexPathSpec:              <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/
-// 	manifestTagIndexEntryPathSpec:         <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/
-// 	manifestTagIndexEntryLinkPathSpec:     <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/link
+//			manifestTagsPathSpec:                  <root>/v2/repositories/<name>/_manifests/tags/
+//			manifestTagPathSpec:                   <root>/v2/repositories/<name>/_manifests/tags/<tag>/
+//			manifestTagCurrentPathSpec:            <root>/v2/repositories/<name>/_manifests/tags/<tag>/current/link
+//			manifestTagIndexPathSpec:              <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/
+//			manifestTagIndexEntryPathSpec:         <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/
+//			manifestTagIndexEntryLinkPathSpec:     <root>/v2/repositories/<name>/_manifests/tags/<tag>/index/<algorithm>/<hex digest>/link
 //
-// 	Blobs:
+//			Blobs:
 //
-// 	layerLinkPathSpec:            <root>/v2/repositories/<name>/_layers/<algorithm>/<hex digest>/link
-// 	layersPathSpec:               <root>/v2/repositories/<name>/_layers
+//			layerLinkPathSpec:            <root>/v2/repositories/<name>/_layers/<algorithm>/<hex digest>/link
+//			layersPathSpec:               <root>/v2/repositories/<name>/_layers
 //
-//	Uploads:
+//			Uploads:
 //
-// 	uploadDataPathSpec:             <root>/v2/repositories/<name>/_uploads/<id>/data
-// 	uploadStartedAtPathSpec:        <root>/v2/repositories/<name>/_uploads/<id>/startedat
-// 	uploadHashStatePathSpec:        <root>/v2/repositories/<name>/_uploads/<id>/hashstates/<algorithm>/<offset>
+//			uploadDataPathSpec:             <root>/v2/repositories/<name>/_uploads/<id>/data
+//			uploadStartedAtPathSpec:        <root>/v2/repositories/<name>/_uploads/<id>/startedat
+//			uploadHashStatePathSpec:        <root>/v2/repositories/<name>/_uploads/<id>/hashstates/<algorithm>/<offset>
 //
-//	Blob Store:
+//		    Referrers:
 //
-//	blobsPathSpec:                  <root>/v2/blobs/
-// 	blobPathSpec:                   <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>
-// 	blobDataPathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
-// 	blobMediaTypePathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
+//	        referrersLinkPathSpec:          <root>/v2/repositories/<name>/_referrers/<algorithm>/<hex digest>/<subject algorithm>/<subject hex digest>/link
+//
+//			Blob Store:
+//
+//			blobsPathSpec:                  <root>/v2/blobs/
+//			blobPathSpec:                   <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>
+//			blobDataPathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
+//			blobMediaTypePathSpec:               <root>/v2/blobs/<algorithm>/<first two hex bytes of digest>/<hex digest>/data
 //
 // For more information on the semantic meaning of each path and their
 // contents, please see the path spec documentation.
@@ -242,6 +246,8 @@ func pathFor(spec pathSpec) (string, error) {
 		return path.Join(append(repoPrefix, v.name, "_uploads", v.id, "hashstates", string(v.alg), offset)...), nil
 	case repositoriesRootPathSpec:
 		return path.Join(repoPrefix...), nil
+	case referrersLinkPathSpec:
+		return path.Join(append(repoPrefix, v.name, "_referrers", v.revision.String(), v.subjectRevision.String(), "link")...), nil
 	default:
 		// TODO(sday): This is an internal error. Ensure it doesn't escape (panic?).
 		return "", fmt.Errorf("unknown path spec: %#v", v)
@@ -349,11 +355,11 @@ func (layersPathSpec) pathSpec() {}
 // blob id. The blob link will contain a content addressable blob id reference
 // into the blob store. The format of the contents is as follows:
 //
-// 	<algorithm>:<hex digest of layer data>
+//	<algorithm>:<hex digest of layer data>
 //
 // The following example of the file contents is more illustrative:
 //
-// 	sha256:96443a84ce518ac22acb2e985eda402b58ac19ce6f91980bde63726a79d80b36
+//	sha256:96443a84ce518ac22acb2e985eda402b58ac19ce6f91980bde63726a79d80b36
 //
 // This  indicates that there is a blob with the id/digest, calculated via
 // sha256 that can be fetched from the blob store.
@@ -436,16 +442,24 @@ type repositoriesRootPathSpec struct {
 
 func (repositoriesRootPathSpec) pathSpec() {}
 
+// referrersLinkPathSpec defines the link path of a referrer.
+type referrersLinkPathSpec struct {
+	name            string
+	revision        digest.Digest
+	subjectRevision digest.Digest
+}
+
+func (referrersLinkPathSpec) pathSpec() {}
+
 // digestPathComponents provides a consistent path breakdown for a given
 // digest. For a generic digest, it will be as follows:
 //
-// 	<algorithm>/<hex digest>
+//	<algorithm>/<hex digest>
 //
 // If multilevel is true, the first two bytes of the digest will separate
 // groups of digest folder. It will be as follows:
 //
-// 	<algorithm>/<first two bytes of digest>/<full digest>
-//
+//	<algorithm>/<first two bytes of digest>/<full digest>
 func digestPathComponents(dgst digest.Digest, multilevel bool) ([]string, error) {
 	if err := dgst.Validate(); err != nil {
 		return nil, err

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -247,7 +247,17 @@ func pathFor(spec pathSpec) (string, error) {
 	case repositoriesRootPathSpec:
 		return path.Join(repoPrefix...), nil
 	case referrersLinkPathSpec:
-		return path.Join(append(repoPrefix, v.name, "_referrers", v.revision.String(), v.subjectRevision.String(), "link")...), nil
+
+		revisionComponents, err := digestPathComponents(v.revision, false)
+		if err != nil {
+			return "", err
+		}
+
+		subjectComponents, err := digestPathComponents(v.subjectRevision, false)
+		if err != nil {
+			return "", err
+		}
+		return path.Join(append(append(append(append(repoPrefix, v.name, "_referrers", "subjects"), revisionComponents...), subjectComponents...), "link")...), nil
 	default:
 		// TODO(sday): This is an internal error. Ensure it doesn't escape (panic?).
 		return "", fmt.Errorf("unknown path spec: %#v", v)

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -40,7 +40,9 @@ const (
 //					data
 //					startedat
 //					hashstates/<algorithm>/<offset>
-//				-> _referrers/
+//				-> _referrers/subjects
+//					-> <revision digest path>
+//						-> <subject digest path>/link
 //
 //		-> blob/<algorithm>
 //			<split directory content addressable storage>

--- a/registry/storage/paths_test.go
+++ b/registry/storage/paths_test.go
@@ -87,6 +87,13 @@ func TestPathMapper(t *testing.T) {
 			spec:     layersPathSpec{name: "foo/bar"},
 			expected: "/docker/registry/v2/repositories/foo/bar/_layers",
 		},
+		{
+			spec: referrersLinkPathSpec{
+				name:            "bar",
+				revision:        "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+				subjectRevision: "sha256:defsbc0123456789defabc0123456789abcdef0123456789abcdef9876543210"},
+			expected: "/docker/registry/v2/repositories/bar/_referrers/sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789/sha256:defsbc0123456789defabc0123456789abcdef0123456789abcdef9876543210/link",
+		},
 	} {
 		p, err := pathFor(testcase.spec)
 		if err != nil {

--- a/registry/storage/paths_test.go
+++ b/registry/storage/paths_test.go
@@ -91,8 +91,8 @@ func TestPathMapper(t *testing.T) {
 			spec: referrersLinkPathSpec{
 				name:            "bar",
 				revision:        "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
-				subjectRevision: "sha256:defsbc0123456789defabc0123456789abcdef0123456789abcdef9876543210"},
-			expected: "/docker/registry/v2/repositories/bar/_referrers/sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789/sha256:defsbc0123456789defabc0123456789abcdef0123456789abcdef9876543210/link",
+				subjectRevision: "sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b"},
+			expected: "/docker/registry/v2/repositories/bar/_referrers/subjects/sha256/abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789/sha256/6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b/link",
 		},
 	} {
 		p, err := pathFor(testcase.spec)

--- a/registry/storage/registry.go
+++ b/registry/storage/registry.go
@@ -289,9 +289,10 @@ func (repo *repository) Manifests(ctx context.Context, options ...distribution.M
 			manifestURLs: repo.registry.manifestURLs,
 		},
 		ociartifactHandler: &ociArtifactManifestHandler{
-			repository: repo,
-			blobStore:  blobStore,
-			ctx:        ctx,
+			repository:    repo,
+			blobStore:     blobStore,
+			ctx:           ctx,
+			storageDriver: repo.driver,
 		},
 	}
 


### PR DESCRIPTION
Part 6 of #21 

This pr implements indexing referrers during manifest push. This is needed to enable the referrers API. It changes the `registry/storage` package. Based on the existing implementation on the [rc2 branch](https://github.com/distribution/distribution/compare/main...oras-project:distribution:rc2).

Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>