### PR TITLE
build: add multi-arch image

### DIFF
--- a/.github/workflows/oras-release.yml
+++ b/.github/workflows/oras-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/oras-release.yml
+++ b/.github/workflows/oras-release.yml
@@ -46,14 +46,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        id: setup_buildx
+
+      - name: Build image
         if: ${{ success() }}
-        uses: docker/build-push-action@v2
+        uses: docker/bake-action@v1
         with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
+          flavor: latest=auto
+          files: |
+            ./docker-bake.hcl
+          targets: image-all
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ steps.get_image_tag.outputs.docker_tag }}
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest
+          set: |
+            image-all.tags=${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ steps.get_image_tag.outputs.docker_tag }}
+            image-all.tags=${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest


### PR DESCRIPTION
This PR reuses upstream Buildx Bake configuration to build multi-arch images for registry.

Resolves: #45 

Signed-off-by: Billy Zha <jinzha1@microsoft.com>