### PR TITLE
fix: should return empty manifest list when no referrers are found

### DIFF
--- a/registry/handlers/referrers.go
+++ b/registry/handlers/referrers.go
@@ -67,9 +67,6 @@ func (h *referrersHandler) GetReferrers(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	referrers, err := h.generateReferrersList(h, h.Digest, artifactTypeFilter)
-	if len(referrers) == 0 {
-		referrers = []v1.Descriptor{}
-	}
 	if err != nil {
 		if _, ok := err.(distribution.ErrManifestUnknownRevision); ok {
 			h.Errors = append(h.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))
@@ -77,6 +74,10 @@ func (h *referrersHandler) GetReferrers(w http.ResponseWriter, r *http.Request) 
 			h.Errors = append(h.Errors, errcode.ErrorCodeUnknown.WithDetail(err))
 		}
 		return
+	}
+
+	if referrers == nil {
+		referrers = []v1.Descriptor{}
 	}
 
 	response := v1.Index{

--- a/registry/handlers/referrers.go
+++ b/registry/handlers/referrers.go
@@ -67,6 +67,9 @@ func (h *referrersHandler) GetReferrers(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	referrers, err := h.generateReferrersList(h, h.Digest, artifactTypeFilter)
+	if len(referrers) == 0 {
+		referrers = []v1.Descriptor{}
+	}
 	if err != nil {
 		if _, ok := err.(distribution.ErrManifestUnknownRevision); ok {
 			h.Errors = append(h.Errors, v2.ErrorCodeManifestUnknown.WithDetail(err))


### PR DESCRIPTION
Resolves #51 
Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>

Current output:
First test case: 0 referrers are found.
Second test case: call with a manifest digest that is nonexistent in the repository, returns an empty manifest list.
![image](https://user-images.githubusercontent.com/103478229/210524449-fced79ce-abb0-4707-a51b-64a84d840854.png)
