### PR TITLE
feat: implement referrers deletion

### DIFF
--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -155,6 +155,12 @@ func (ms *manifestStore) Put(ctx context.Context, manifest distribution.Manifest
 func (ms *manifestStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	dcontext.GetLogger(ms.ctx).Debug("(*manifestStore).Delete")
 
+	// Ensure the blob is available for deletion
+	_, err := ms.blobStore.blobAccessController.Stat(ctx, dgst)
+	if err != nil {
+		return err
+	}
+
 	// delete the manifest from its subject's indexed referrers, if applicable
 	content, err := ms.blobStore.Get(ctx, dgst)
 	if err != nil {

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -168,7 +168,7 @@ func (ms *manifestStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	// Remove the manifest from its subject's indexed referrers, if applicable
 	man, err := ms.Get(ctx, dgst)
 	if err != nil {
-		return fmt.Errorf("unable to retrieve manifest %w", err)
+		return fmt.Errorf("unable to retrieve manifest: %w", err)
 	}
 
 	var subject *distribution.Descriptor
@@ -177,8 +177,6 @@ func (ms *manifestStore) Delete(ctx context.Context, dgst digest.Digest) error {
 		subject = m.Subject
 	case *ocischema.DeserializedManifest:
 		subject = m.Subject
-	default:
-		return ms.blobStore.Delete(ctx, dgst)
 	}
 
 	if subject != nil {

--- a/registry/storage/manifeststore.go
+++ b/registry/storage/manifeststore.go
@@ -155,6 +155,10 @@ func (ms *manifestStore) Put(ctx context.Context, manifest distribution.Manifest
 func (ms *manifestStore) Delete(ctx context.Context, dgst digest.Digest) error {
 	dcontext.GetLogger(ms.ctx).Debug("(*manifestStore).Delete")
 
+	if !ms.blobStore.deleteEnabled {
+		return distribution.ErrUnsupported
+	}
+
 	// Ensure the blob is available for deletion
 	_, err := ms.blobStore.blobAccessController.Stat(ctx, dgst)
 	if err != nil {
@@ -198,7 +202,7 @@ func (ms *manifestStore) Delete(ctx context.Context, dgst digest.Digest) error {
 		}
 	}
 
-	return ms.blobStore.Delete(ctx, dgst)
+	return ms.blobStore.blobAccessController.Clear(ctx, dgst)
 }
 
 func (ms *manifestStore) Enumerate(ctx context.Context, ingester func(digest.Digest) error) error {

--- a/registry/storage/paths.go
+++ b/registry/storage/paths.go
@@ -41,8 +41,8 @@ const (
 //					startedat
 //					hashstates/<algorithm>/<offset>
 //				-> _referrers/subjects
-//					-> <revision digest path>
-//						-> <subject digest path>/link
+//					-> <subject digest path>
+//						-> <revision digest path>/link
 //
 //		-> blob/<algorithm>
 //			<split directory content addressable storage>
@@ -101,7 +101,7 @@ const (
 //
 //	Referrers:
 //
-//	referrersLinkPathSpec:          <root>/v2/repositories/<name>/_referrers/subjects/<algorithm>/<hex digest>/<subject algorithm>/<subject hex digest>/link
+//	referrersLinkPathSpec:          <root>/v2/repositories/<name>/_referrers/subjects/<subject algorithm>/<subject hex digest>/<algorithm>/<hex digest>/link
 //
 //	Blob Store:
 //


### PR DESCRIPTION
Part 2 of and Resolves #37 

Basic Test result using `oras`:
delete a referrer of an artifact manifest
![image](https://user-images.githubusercontent.com/103478229/210692190-9d0b99be-4aff-40af-a9ab-12a97725aa69.png)
![image](https://user-images.githubusercontent.com/103478229/210692259-753d55df-aead-4308-9aab-dd900611884b.png)

delete a referrer of an image manifest
![image](https://user-images.githubusercontent.com/103478229/210701360-7d49a5ad-59d9-431e-91ca-2d09c16c4253.png)

Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>