### PR TITLE
feat: enable referrers pagination

### DIFF
--- a/registry/handlers/referrers.go
+++ b/registry/handlers/referrers.go
@@ -104,7 +104,7 @@ func (h *referrersHandler) GetReferrers(w http.ResponseWriter, r *http.Request) 
 
 	startIndex := pageNumber * pageSize
 
-	if referrers == nil || startIndex > len(referrers) {
+	if referrers == nil || startIndex >= len(referrers) {
 		referrers = []v1.Descriptor{}
 	}
 

--- a/registry/handlers/referrers.go
+++ b/registry/handlers/referrers.go
@@ -106,9 +106,7 @@ func (h *referrersHandler) GetReferrers(w http.ResponseWriter, r *http.Request) 
 
 	if referrers == nil || startIndex >= len(referrers) {
 		referrers = []v1.Descriptor{}
-	}
-
-	if len(referrers) > pageSize {
+	} else {
 		// if there's only 1 page of results left
 		if len(referrers)-startIndex <= pageSize {
 			referrers = referrers[startIndex:]

--- a/registry/handlers/referrers.go
+++ b/registry/handlers/referrers.go
@@ -110,7 +110,7 @@ func (h *referrersHandler) GetReferrers(w http.ResponseWriter, r *http.Request) 
 		// only 1 page of results left
 		referrers = referrers[startIndex:]
 	} else {
-		referrers = referrers[startIndex:(startIndex + pageSize)]
+		referrers = referrers[startIndex : startIndex+pageSize]
 		w.Header().Set("Link", generateLinkHeader(h.Repository.Named().Name(), h.Digest.String(), artifactTypeFilter, pageSize, pageNumber+1))
 	}
 
@@ -229,10 +229,10 @@ func readlink(ctx context.Context, path string, stDriver driver.StorageDriver) (
 	return digest.Parse(string(content))
 }
 
-func generateLinkHeader(repoName, subjectDigest, artifactType string, pageSize int, p int) string {
+func generateLinkHeader(repoName, subjectDigest, artifactType string, pageSize int, pageNumber int) string {
 	linkURL := fmt.Sprintf("/v2/%s/referrers/%s", repoName, subjectDigest)
 	v := url.Values{}
-	v.Add("p", strconv.Itoa(p))
+	v.Add("p", strconv.Itoa(pageNumber))
 	if artifactType != "" {
 		v.Add("artifactType", artifactType)
 	}

--- a/registry/handlers/referrers.go
+++ b/registry/handlers/referrers.go
@@ -108,12 +108,14 @@ func (h *referrersHandler) GetReferrers(w http.ResponseWriter, r *http.Request) 
 		referrers = []v1.Descriptor{}
 	}
 
-	// if there's only 1 page of results left
-	if len(referrers)-startIndex <= pageSize {
-		referrers = referrers[startIndex:]
-	} else {
-		referrers = referrers[startIndex:(startIndex + pageSize)]
-		w.Header().Set("Link", generateLinkHeader(h.Repository.Named().Name(), h.Digest.String(), artifactTypeFilter, pageSize, pageNumber+1))
+	if len(referrers) > pageSize {
+		// if there's only 1 page of results left
+		if len(referrers)-startIndex <= pageSize {
+			referrers = referrers[startIndex:]
+		} else {
+			referrers = referrers[startIndex:(startIndex + pageSize)]
+			w.Header().Set("Link", generateLinkHeader(h.Repository.Named().Name(), h.Digest.String(), artifactTypeFilter, pageSize, pageNumber+1))
+		}
 	}
 
 	response := v1.Index{


### PR DESCRIPTION
Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>

Resolves #40 

This pr enables the pagination feature of referrers API. The current implementation is slow as it calls `generateReferrersList` multiple times when pagination is needed.

Users can define page size by using the `?n` query parameter. If not used, the default page size is set to 100. Pagination is automatically enabled when the number of returned referrers is greater than the page size (this is conformant to the distribution spec).

- Test result with `pageSize = 4`. The test subject has 6 referrers and are returned with 2 pages.
![image](https://user-images.githubusercontent.com/103478229/213588372-430de8d9-7eab-4477-bd51-e59b1fd87c2f.png)

- Test result with `pageSize = 5` using the same test subject. 2 Pages are returned.
![image](https://user-images.githubusercontent.com/103478229/213588701-fac1f443-3fca-4cf6-8b2c-9c51f2d59e52.png)
